### PR TITLE
Add support for light skin

### DIFF
--- a/Assets/UnityShell/Editor/Scripts/UnityShellEditorWindow.cs
+++ b/Assets/UnityShell/Editor/Scripts/UnityShellEditorWindow.cs
@@ -13,13 +13,13 @@ namespace UnityShell
 			public static readonly GUIStyle textAreaStyle;
 
 			// Default background Color(0.76f, 0.76f, 0.76f)
-			private static readonly Color BgColorLightSkin = new Color(0.87f, 0.87f, 0.87f);
+			private static readonly Color bgColorLightSkin = new Color(0.87f, 0.87f, 0.87f);
 			// Default background Color(0.22f, 0.22f, 0.22f)
-			private static readonly Color BgColorDarkSkin = new Color(0.11f, 0.11f, 0.11f);
+			private static readonly Color bgColorDarkSkin = new Color(0.2f, 0.2f, 0.2f);
 			// Default text Color(0.0f, 0.0f, 0.0f)
-			private static readonly Color TextColorLightSkin = new Color(0.0f, 0.0f, 0.0f);
+			private static readonly Color textColorLightSkin = new Color(0.0f, 0.0f, 0.0f);
 			// Default text Color(0.706f, 0.706f, 0.706f)
-			private static readonly Color TextColorDarkSkin = new Color(0.706f, 0.706f, 0.706f);
+			private static readonly Color textColorDarkSkin = new Color(0.706f, 0.706f, 0.706f);
 			
 			static Texture2D _backgroundTexture;
 			public static Texture2D backgroundTexture
@@ -29,7 +29,7 @@ namespace UnityShell
 					if(_backgroundTexture == null)
 					{
 						_backgroundTexture = new Texture2D(1, 1, TextureFormat.RGBA32, false, true);
-						_backgroundTexture.SetPixel(0, 0, EditorGUIUtility.isProSkin ? BgColorDarkSkin : BgColorLightSkin);
+						_backgroundTexture.SetPixel(0, 0, EditorGUIUtility.isProSkin ? bgColorDarkSkin : bgColorLightSkin);
 						_backgroundTexture.Apply();
 					}
 					return _backgroundTexture;
@@ -43,7 +43,7 @@ namespace UnityShell
 
 				var style = textAreaStyle.focused;
 				style.background = backgroundTexture;
-				style.textColor = EditorGUIUtility.isProSkin ? TextColorDarkSkin : TextColorLightSkin;
+				style.textColor = EditorGUIUtility.isProSkin ? textColorDarkSkin : textColorLightSkin;
 
 				textAreaStyle.focused = style;
 				textAreaStyle.active = style;

--- a/Assets/UnityShell/Editor/Scripts/UnityShellEditorWindow.cs
+++ b/Assets/UnityShell/Editor/Scripts/UnityShellEditorWindow.cs
@@ -11,7 +11,15 @@ namespace UnityShell
 		static class Styles
 		{
 			public static readonly GUIStyle textAreaStyle;
-
+			// Default background Color(0.76f, 0.76f, 0.76f)
+			public static Color BgColorLightSkin = new Color(0.87f, 0.87f, 0.87f);
+			// Default background Color(0.22f, 0.22f, 0.22f)
+			public static Color BgColorDarkSkin = new Color(0.11f, 0.11f, 0.11f);
+			// Default text Color(0.0f, 0.0f, 0.0f)
+			public static Color TextColorLightSkin = new Color(0.0f, 0.0f, 0.0f);
+			// Default text Color(0.706f, 0.706f, 0.706f)
+			public static Color TextColorDarkSkin = new Color(0.706f, 0.706f, 0.706f);
+			
 			static Texture2D _backgroundTexture;
 			public static Texture2D backgroundTexture
 			{
@@ -19,8 +27,8 @@ namespace UnityShell
 				{
 					if(_backgroundTexture == null)
 					{
-						_backgroundTexture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
-						_backgroundTexture.SetPixel(0, 0, new Color(.18f, .18f, .18f));
+						_backgroundTexture = new Texture2D(1, 1, TextureFormat.RGBA32, false, true);
+						_backgroundTexture.SetPixel(0, 0, EditorGUIUtility.isProSkin?BgColorDarkSkin:BgColorLightSkin);
 						_backgroundTexture.Apply();
 					}
 					return _backgroundTexture;
@@ -34,7 +42,7 @@ namespace UnityShell
 
 				var style = textAreaStyle.focused;
 				style.background = backgroundTexture;
-				style.textColor = new Color(.7f, .7f, .7f);
+				style.textColor = EditorGUIUtility.isProSkin ? TextColorDarkSkin : TextColorLightSkin;
 
 				textAreaStyle.focused = style;
 				textAreaStyle.active = style;

--- a/Assets/UnityShell/Editor/Scripts/UnityShellEditorWindow.cs
+++ b/Assets/UnityShell/Editor/Scripts/UnityShellEditorWindow.cs
@@ -11,14 +11,15 @@ namespace UnityShell
 		static class Styles
 		{
 			public static readonly GUIStyle textAreaStyle;
+
 			// Default background Color(0.76f, 0.76f, 0.76f)
-			public static Color BgColorLightSkin = new Color(0.87f, 0.87f, 0.87f);
+			private static readonly Color BgColorLightSkin = new Color(0.87f, 0.87f, 0.87f);
 			// Default background Color(0.22f, 0.22f, 0.22f)
-			public static Color BgColorDarkSkin = new Color(0.11f, 0.11f, 0.11f);
+			private static readonly Color BgColorDarkSkin = new Color(0.11f, 0.11f, 0.11f);
 			// Default text Color(0.0f, 0.0f, 0.0f)
-			public static Color TextColorLightSkin = new Color(0.0f, 0.0f, 0.0f);
+			private static readonly Color TextColorLightSkin = new Color(0.0f, 0.0f, 0.0f);
 			// Default text Color(0.706f, 0.706f, 0.706f)
-			public static Color TextColorDarkSkin = new Color(0.706f, 0.706f, 0.706f);
+			private static readonly Color TextColorDarkSkin = new Color(0.706f, 0.706f, 0.706f);
 			
 			static Texture2D _backgroundTexture;
 			public static Texture2D backgroundTexture
@@ -28,7 +29,7 @@ namespace UnityShell
 					if(_backgroundTexture == null)
 					{
 						_backgroundTexture = new Texture2D(1, 1, TextureFormat.RGBA32, false, true);
-						_backgroundTexture.SetPixel(0, 0, EditorGUIUtility.isProSkin?BgColorDarkSkin:BgColorLightSkin);
+						_backgroundTexture.SetPixel(0, 0, EditorGUIUtility.isProSkin ? BgColorDarkSkin : BgColorLightSkin);
 						_backgroundTexture.Apply();
 					}
 					return _backgroundTexture;


### PR DESCRIPTION
Add color defines for text and background for light and dark skin. This is necessary since the text cursor is black for the light skin. Therefore you won't see it on such a dark background.
I also changed the background texture to use linear color space since this matches the correct colors in the editor. ⚡