### PR TITLE
Add handling of copy, cut, paste, select all

### DIFF
--- a/Assets/UnityShell/Editor/Scripts/UnityShellEditorWindow.cs
+++ b/Assets/UnityShell/Editor/Scripts/UnityShellEditorWindow.cs
@@ -198,7 +198,7 @@ namespace UnityShell
             {
                 textEditor.selectIndex = textEditor.text.Length;
                 // Don't select the command start text
-                textEditor.cursorIndex = CommandName.Length;
+                textEditor.cursorIndex = text.LastIndexOf(CommandName, StringComparison.Ordinal) + CommandName.Length;
                 current.Use();
                 return;
             }

--- a/Assets/UnityShell/Editor/Scripts/UnityShellEditorWindow.cs
+++ b/Assets/UnityShell/Editor/Scripts/UnityShellEditorWindow.cs
@@ -150,6 +150,7 @@ namespace UnityShell
 			}
 
 			EnsureNotAboutToTypeAtInvalidPosition();
+            HandleTextCommands();
 			autocompleteBox.HandleEvents();
 			HandleHistory();
 			DoAutoComplete();
@@ -157,7 +158,53 @@ namespace UnityShell
 			DrawAll();
 		}
 
-		private void HandleHistory()
+        private void HandleTextCommands()
+        {
+            var current = Event.current;
+
+            if (current.type != EventType.ValidateCommand)
+            {
+                return;
+            }
+            
+            if (current.commandName == "Copy")
+            {
+                textEditor.Copy();
+                current.Use();
+                return;
+            }
+            
+            if (current.commandName == "Cut")
+            {
+                var success = textEditor.Cut();
+                if (success)
+                {
+                    current.Use();
+                }
+                return;
+            }
+            
+            if (current.commandName == "Paste")
+            {
+                var success = textEditor.Paste();
+                if (success)
+                {
+                    current.Use();
+                }
+                return;
+            }
+            
+            if (current.commandName == "SelectAll")
+            {
+                textEditor.selectIndex = textEditor.text.Length;
+                // Don't select the command start text
+                textEditor.cursorIndex = CommandName.Length;
+                current.Use();
+                return;
+            }
+        }
+
+        private void HandleHistory()
 		{
 			var current = Event.current;
 			if (current.type == EventType.KeyDown)

--- a/Assets/UnityShell/Editor/Scripts/UnityShellEditorWindow.cs
+++ b/Assets/UnityShell/Editor/Scripts/UnityShellEditorWindow.cs
@@ -143,7 +143,7 @@ namespace UnityShell
 		private void OnGUI()
 		{
 			textEditor = (TextEditor) GUIUtility.GetStateObject(typeof(TextEditor), GUIUtility.keyboardControl);
-			if (text == "")
+			if (string.IsNullOrEmpty(text))
 			{
 				AppendStartCommand();
 				ScheduleMoveCursorToEnd();
@@ -322,7 +322,7 @@ namespace UnityShell
 				var lastIndexCommand = text.LastIndexOf(CommandName, StringComparison.Ordinal) + CommandName.Length;
 
 				var cursorIndex = textEditor.cursorIndex;
-				if (current.keyCode == KeyCode.Backspace)
+				if (current.keyCode == KeyCode.Backspace && !textEditor.hasSelection)
 				{
 					cursorIndex--;
 


### PR DESCRIPTION
Add support for common shortcuts:
- Copy selected text
- Cut selected text
- Paste Text from Clipboard
- Select complete command input

Missing Support:
- Undo & Redo (Sadly not that easy)

Still, I think this makes the UX a lot better. I was missing Copy&Paste a lot.